### PR TITLE
fix: `text` wrapper around `fmt::format`

### DIFF
--- a/include/yui/widgets.h
+++ b/include/yui/widgets.h
@@ -180,8 +180,8 @@ public:
      * @brief   Create a formatted text
      */
     template <typename... Args>
-    Derived& text(const std::string& fmt, Args&&... args) {
-        ImGui::Text("%s", fmt::vformat(fmt, fmt::make_format_args(std::forward<Args>(args)...)).c_str());
+    Derived& text(fmt::format_string<Args...> fmt, Args&&... args) {
+        ImGui::Text("%s", fmt::format(fmt, std::forward<Args>(args)...).c_str());
         return *static_cast<Derived*>(this);
     }
 


### PR DESCRIPTION
Now it is properly forwarding the formatting to `fmt`, meaning it does not rely on runtime checking, but compile time.

`fmt::make_format_args` is not for runtime format strings anyway.

Reference: DR23: std::make_format_args now accepts only lvalue references instead of forwarding references

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2905r2.html#proposal